### PR TITLE
Add start-page single type with i18n translations for /start page

### DIFF
--- a/src/api/start-page/content-types/start-page/schema.json
+++ b/src/api/start-page/content-types/start-page/schema.json
@@ -1,0 +1,115 @@
+{
+  "kind": "singleType",
+  "collectionName": "start_pages",
+  "info": {
+    "singularName": "start-page",
+    "pluralName": "start-pages",
+    "displayName": "Start_page"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
+  "attributes": {
+    "Heading": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    },
+    "Client_Input_Placeholder": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    },
+    "Client_Load_Button": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    },
+    "Scan_Button": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    },
+    "Search_Placeholder": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    },
+    "No_Client_Text": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    },
+    "Searching_Text": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    },
+    "Select_Button": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    },
+    "Confirm_Heading": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    },
+    "Confirm_Subtext": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    },
+    "Search_Again_Button": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    },
+    "Continue_Button": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    }
+  }
+}

--- a/src/api/start-page/controllers/start-page.js
+++ b/src/api/start-page/controllers/start-page.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * start-page controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::start-page.start-page');

--- a/src/api/start-page/routes/start-page.js
+++ b/src/api/start-page/routes/start-page.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * start-page router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::start-page.start-page');

--- a/src/api/start-page/services/start-page.js
+++ b/src/api/start-page/services/start-page.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * start-page service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::start-page.start-page');

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -2678,6 +2678,118 @@ export interface ApiPropProp extends Schema.CollectionType {
   };
 }
 
+export interface ApiStartPageStartPage extends Schema.SingleType {
+  collectionName: 'start_pages';
+  info: {
+    singularName: 'start-page';
+    pluralName: 'start-pages';
+    displayName: 'Start_page';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  pluginOptions: {
+    i18n: {
+      localized: true;
+    };
+  };
+  attributes: {
+    Heading: Attribute.String &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    Client_Input_Placeholder: Attribute.String &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    Client_Load_Button: Attribute.String &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    Scan_Button: Attribute.String &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    Search_Placeholder: Attribute.String &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    No_Client_Text: Attribute.String &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    Searching_Text: Attribute.String &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    Select_Button: Attribute.String &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    Confirm_Heading: Attribute.String &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    Confirm_Subtext: Attribute.String &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    Search_Again_Button: Attribute.String &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    Continue_Button: Attribute.String &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::start-page.start-page',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::start-page.start-page',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    localizations: Attribute.Relation<
+      'api::start-page.start-page',
+      'oneToMany',
+      'api::start-page.start-page'
+    >;
+    locale: Attribute.String;
+  };
+}
+
 export interface ApiValidateCustomerValidateCustomer extends Schema.SingleType {
   collectionName: 'validate_customers';
   info: {
@@ -2853,6 +2965,7 @@ declare module '@strapi/types' {
       'api::my-contracts.my-contracts': ApiMyContractsMyContracts;
       'api::promotion.promotion': ApiPromotionPromotion;
       'api::prop.prop': ApiPropProp;
+      'api::start-page.start-page': ApiStartPageStartPage;
       'api::validate-customer.validate-customer': ApiValidateCustomerValidateCustomer;
     }
   }


### PR DESCRIPTION
## Summary

The frontend `/start` page requests CMS copy via `/api/cms-strapi?route=start-page&locale=...` (proxied through the FastAPI `/cms/strapi` endpoint), but no `start-page` content type existed in Strapi. Every lookup 404'd, so the page silently fell back to its hardcoded English defaults.

This adds a localized **Start_page** single type following the same pattern as `customer-hub`, `basket`, and `my-contracts`, with the 12 translation keys used by `StartPageContent.tsx`:

`Heading`, `Client_Input_Placeholder`, `Client_Load_Button`, `Scan_Button`, `Search_Placeholder`, `No_Client_Text`, `Searching_Text`, `Select_Button`, `Confirm_Heading`, `Confirm_Subtext`, `Search_Again_Button`, `Continue_Button`

## Changes

- `src/api/start-page/content-types/start-page/schema.json` — single type, draft & publish enabled, all fields i18n-localized strings
- `src/api/start-page/{controllers,routes,services}/start-page.js` — standard core factory boilerplate
- `types/generated/contentTypes.d.ts` — added matching `ApiStartPageStartPage` entry

## Post-deploy steps

1. In the Strapi admin, fill in the new **Start_page** single type for each locale and **publish** it.
2. If the API token used by the FastAPI proxy (`STRAPI_BEARER_TOKEN`) is custom-scoped, enable `find` for `start-page` on it.

No frontend or embedding changes required — the response shape (`data.data.attributes`) and locale conversion already match.

https://claude.ai/code/session_01JpGavE7eTfTfV2EBkznBUF

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpGavE7eTfTfV2EBkznBUF)_