### PR TITLE
fix: add missing controller, routes, and service for portal-admin

### DIFF
--- a/src/api/portal-admin/controllers/portal-admin.js
+++ b/src/api/portal-admin/controllers/portal-admin.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * portal-admin controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::portal-admin.portal-admin');

--- a/src/api/portal-admin/routes/portal-admin.js
+++ b/src/api/portal-admin/routes/portal-admin.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * portal-admin router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::portal-admin.portal-admin');

--- a/src/api/portal-admin/services/portal-admin.js
+++ b/src/api/portal-admin/services/portal-admin.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * portal-admin service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::portal-admin.portal-admin');


### PR DESCRIPTION
The portal-admin single type (PR #34) shipped with only its schema.json. Without the core factory companion files, Strapi's i18n plugin crashes at bootstrap with "Cannot read properties of undefined (reading 'routes')", causing the Railway deploy to crash-loop and fail its healthcheck.