### PR TITLE
Add cookie-banner single type for cookie consent banner content

### DIFF
--- a/seed-cookie-banner.js
+++ b/seed-cookie-banner.js
@@ -1,0 +1,127 @@
+'use strict';
+
+/**
+ * Seed script: populates the cookie-banner single type with English default values.
+ * Usage: node seed-cookie-banner.js <adminEmail> <adminPassword>
+ * Example: node seed-cookie-banner.js admin@example.com mypassword
+ */
+
+const http = require('http');
+const https = require('https');
+
+const BASE_URL = process.env.STRAPI_URL || 'http://localhost:1337';
+const EMAIL    = process.argv[2];
+const PASSWORD = process.argv[3];
+
+if (!EMAIL || !PASSWORD) {
+  console.error('Usage: node seed-cookie-banner.js <adminEmail> <adminPassword>');
+  process.exit(1);
+}
+
+function request(method, path, body, token) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(BASE_URL + path);
+    const isHttps = url.protocol === 'https:';
+    const lib = isHttps ? https : http;
+    const payload = body ? JSON.stringify(body) : null;
+
+    const options = {
+      hostname: url.hostname,
+      port: url.port || (isHttps ? 443 : 80),
+      path: url.pathname + url.search,
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        ...(payload ? { 'Content-Length': Buffer.byteLength(payload) } : {}),
+      },
+    };
+
+    const req = lib.request(options, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => {
+        try {
+          resolve({ status: res.statusCode, body: JSON.parse(data) });
+        } catch {
+          resolve({ status: res.statusCode, body: data });
+        }
+      });
+    });
+
+    req.on('error', reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+const EN_VALUES = {
+  // Consent banner
+  Banner_Title: 'We value your privacy',
+  Banner_Description:
+    'We use cookies to make this site work and, with your permission, to understand how it is used. You can change your choice at any time via Cookie settings.',
+  Accept_All_Button: 'Accept all',
+  Reject_All_Button: 'Reject non-essential',
+  Manage_Preferences_Button: 'Manage preferences',
+
+  // Preferences modal
+  Modal_Title: 'Cookie preferences',
+  Save_Preferences_Button: 'Save preferences',
+
+  // Categories
+  Necessary_Title: 'Strictly necessary',
+  Necessary_Description:
+    'Required for core functionality such as secure sessions. Always on.',
+  Analytics_Title: 'Analytics',
+  Analytics_Description: 'Help us understand how the site is used.',
+  Marketing_Title: 'Marketing',
+  Marketing_Description: 'Used to personalise offers and measure campaigns.',
+};
+
+async function main() {
+  console.log(`Connecting to Strapi at ${BASE_URL}…`);
+
+  // 1. Log in to get admin JWT
+  const loginRes = await request('POST', '/admin/login', { email: EMAIL, password: PASSWORD });
+  if (loginRes.status !== 200) {
+    console.error('Login failed:', JSON.stringify(loginRes.body));
+    process.exit(1);
+  }
+  const token = loginRes.body?.data?.token;
+  console.log('Logged in successfully.');
+
+  // 2. Fetch all configured locales
+  const localesRes = await request('GET', '/i18n/locales', null, token);
+  const locales = localesRes.body;
+  const defaultLocale = locales.find(l => l.isDefault) || locales[0];
+  console.log(`Default locale: ${defaultLocale.code}`);
+  console.log(`All locales: ${locales.map(l => l.code).join(', ')}`);
+
+  // 3. Write English values to the default locale first
+  const cmBase = '/content-manager/single-types/api::cookie-banner.cookie-banner';
+  console.log(`\nWriting English values to default locale (${defaultLocale.code})…`);
+  const defaultRes = await request('PUT', `${cmBase}?locale=${defaultLocale.code}`, EN_VALUES, token);
+  if (defaultRes.status >= 200 && defaultRes.status < 300) {
+    console.log(`✓ ${defaultLocale.code} — saved.`);
+  } else {
+    console.error(`✗ ${defaultLocale.code} failed:`, JSON.stringify(defaultRes.body, null, 2));
+    process.exit(1);
+  }
+
+  // 4. Create placeholder entries for all other locales (English values as fallback)
+  const otherLocales = locales.filter(l => l.code !== defaultLocale.code);
+  for (const locale of otherLocales) {
+    console.log(`Writing placeholder values to ${locale.code}…`);
+    const res = await request('PUT', `${cmBase}?locale=${locale.code}`, EN_VALUES, token);
+    if (res.status >= 200 && res.status < 300) {
+      console.log(`✓ ${locale.code} — saved.`);
+    } else {
+      console.warn(`✗ ${locale.code} failed:`, JSON.stringify(res.body, null, 2));
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error('Unexpected error:', err);
+  process.exit(1);
+});

--- a/src/api/cookie-banner/content-types/cookie-banner/schema.json
+++ b/src/api/cookie-banner/content-types/cookie-banner/schema.json
@@ -1,0 +1,123 @@
+{
+  "kind": "singleType",
+  "collectionName": "cookie_banners",
+  "info": {
+    "singularName": "cookie-banner",
+    "pluralName": "cookie-banners",
+    "displayName": "Cookie_Banner"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
+  "attributes": {
+    "Banner_Title": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    },
+    "Banner_Description": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "text"
+    },
+    "Accept_All_Button": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    },
+    "Reject_All_Button": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    },
+    "Manage_Preferences_Button": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    },
+    "Modal_Title": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    },
+    "Save_Preferences_Button": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    },
+    "Necessary_Title": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    },
+    "Necessary_Description": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "text"
+    },
+    "Analytics_Title": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    },
+    "Analytics_Description": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "text"
+    },
+    "Marketing_Title": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    },
+    "Marketing_Description": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "text"
+    }
+  }
+}

--- a/src/api/cookie-banner/controllers/cookie-banner.js
+++ b/src/api/cookie-banner/controllers/cookie-banner.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * cookie-banner controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::cookie-banner.cookie-banner');

--- a/src/api/cookie-banner/routes/cookie-banner.js
+++ b/src/api/cookie-banner/routes/cookie-banner.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * cookie-banner router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::cookie-banner.cookie-banner');

--- a/src/api/cookie-banner/services/cookie-banner.js
+++ b/src/api/cookie-banner/services/cookie-banner.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * cookie-banner service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::cookie-banner.cookie-banner');


### PR DESCRIPTION
## Summary

Adds a new localized **`Cookie_Banner` single type** holding all text for the frontend's GDPR cookie consent manager (built with the open-source vanilla-cookieconsent v3 library — see the companion PR in `ActivlinkDev/frontend`).

- Fields cover the consent banner (title, description, accept/reject/manage buttons), the preferences modal (title, save button), and the three consent categories — necessary / analytics / marketing (title + description each)
- Follows the existing single-type pattern (flat localized string/text fields, factory controller/router/service), so `strapi-plugin-translate` + DeepL work on it out of the box
- Adds `seed-cookie-banner.js` to populate English defaults (same pattern as `seed-my-contracts.js`)

## Post-deploy steps

1. Restart/redeploy Strapi so the content type registers and the table is created
2. Seed English defaults: `node seed-cookie-banner.js <adminEmail> <adminPassword>`
3. Translate the other locales via the DeepL translate plugin, then **publish** each locale
4. If the frontend's `STRAPI_API_TOKEN` is a custom-scoped token, grant it `cookie-banner.find` (full-access tokens need nothing)

https://claude.ai/code/session_01YCaB6KEWb2zXFcHi6VWZmf

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCaB6KEWb2zXFcHi6VWZmf)_