### PR TITLE
Add replacement-value tooltip and compare-prices labels to Display_Device

### DIFF
--- a/src/api/display-device/content-types/display-device/schema.json
+++ b/src/api/display-device/content-types/display-device/schema.json
@@ -319,6 +319,38 @@
         }
       },
       "type": "string"
+    },
+    "Estimated_Replacement_Value": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    },
+    "Estimated_Replacement_Value_Info": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    },
+    "Compare_Prices": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    },
+    "Compare_Prices_Explainer": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "text"
     }
   }
 }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1539,6 +1539,30 @@ export interface ApiDisplayDeviceDisplayDevice extends Schema.SingleType {
           localized: true;
         };
       }>;
+    Estimated_Replacement_Value: Attribute.String &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    Estimated_Replacement_Value_Info: Attribute.String &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    Compare_Prices: Attribute.String &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    Compare_Prices_Explainer: Attribute.Text &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     createdBy: Attribute.Relation<


### PR DESCRIPTION
## What

Adds localized CMS label fields to the `Display_Device` single type (served via `/api/cms` to the product information page) backing the estimated replacement value info icon and the compare-prices lightbox.

## Fields added (all i18n-localized)

| Key | Type | Used for |
|---|---|---|
| `Estimated_Replacement_Value` | string | Row label |
| `Estimated_Replacement_Value_Info` | string | Info icon tooltip / aria-label |
| `Compare_Prices` | string | "Compare prices" button |
| `Compare_Prices_Explainer` | text | Lightbox explainer text |

`Estimated_Replacement_Value` and `Compare_Prices` were already referenced by the frontend via `getLabel()` but had no CMS field (only hardcoded English fallbacks); they're now editable too.

## Notes

- This is a schema change — it takes effect after a Strapi restart/redeploy that syncs content types.
- Translated values per locale still need to be entered by an editor in the Strapi admin; the frontend uses English fallbacks until then.

Pairs with the frontend PR on the same branch (`claude/product-info-cost-tooltip-nj5ep4`).

https://claude.ai/code/session_01LhDZE1Q1ik8iETYB5oQ3TE

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhDZE1Q1ik8iETYB5oQ3TE)_