### PR TITLE
Increase Railway healthcheck timeout to 420s for Strapi v5 first-boot migration

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "deploy": {
+    "healthcheckTimeout": 420
+  }
+}


### PR DESCRIPTION
## Why

After the Strapi v5 dependency fix (#40), the app builds and starts successfully on Railway but the **deploy** stage still fails: the v5 upgrade runs a database migration on first boot, pushing total startup to ~343s, which exceeds Railway's default **300s** healthcheck window. Railway kills the container before it can serve the healthcheck.

## Change

Adds `railway.json` setting `deploy.healthcheckTimeout` to **420s**, giving ~77s of headroom over the observed ~343s startup. Only the timeout is set, so the existing dashboard healthcheck path and other deploy settings are preserved.

```json
{
  "$schema": "https://railway.com/railway.schema.json",
  "deploy": {
    "healthcheckTimeout": 420
  }
}
```

## Note

The long startup is a one-time first-boot migration; subsequent boots should be much faster. The larger timeout is harmless headroom.

https://claude.ai/code/session_01LhDZE1Q1ik8iETYB5oQ3TE

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhDZE1Q1ik8iETYB5oQ3TE)_